### PR TITLE
chore(ci): fix semantic-release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,19 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write       # allow semantic-release to push tags
+  issues: write         # allow @semantic-release/github to open failure issues
+  pull-requests: write  # allow status updates/comments if needed
+
 jobs:
   release:
     name: Publish to NPM
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     
     # We shouldn't release if CI hasn't passed, though push triggers run in parallel so 
     # github protects main anyway. But to be safe in a strict pipeline:
@@ -19,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
- grant contents/issues/pull-requests write permissions so semantic-release can push tags and open failure issues
- checkout fetch-depth: 0 for tag history

This fixes the main-branch release failure where the github-actions bot lacked permission to push tags and create the automated failure issue.