### PR TITLE
feat: release 1.1.0

### DIFF
--- a/RELEASE_TRIGGER.md
+++ b/RELEASE_TRIGGER.md
@@ -1,0 +1,2 @@
+This commit intentionally contains a `feat` prefix to trigger semantic-release to publish version 1.1.0 after the pipeline permissions fix.
+


### PR DESCRIPTION
Trigger semantic-release to publish 1.1.0 now that permissions and dist output are fixed.