### PR TITLE
feat: release version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 1.2.0 (2026-04-22)
+
+### Features
+
+- expand AST extraction to include exported interfaces, classes, class methods, and type aliases
+- support interface/class generics and class method overload declarations
+- parse abstract class methods and decorator metadata in extracted signatures
+
+### Bug Fixes
+
+- prevent private class methods from being surfaced in documentation drift checks
+- normalize multiline signatures to stable one-line comparison format
+
+### Documentation
+
+- refresh README usage and extraction details for the 1.2.0 symbol coverage
+
 ## 1.1.0 (2026-04-11)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Stop documentation drift in its tracks.**
 
-`doc-sync-check` is a fast, specialized CLI tool that statically analyzes your TypeScript codebase using an Abstract Syntax Tree (AST). It scans your Markdown files for function names and ensures that the documented function signatures match the actual source code perfectly. 
+`doc-sync-check` is a fast, specialized CLI tool that statically analyzes your TypeScript codebase using an Abstract Syntax Tree (AST). It scans your Markdown files for exported symbols and ensures that documented signatures match source code.
 
 If you update a parameter or return type in your code but forget to update the documentation, `doc-sync-check` will catch it and fail your CI build, reminding your team to keep the docs in sync!
 
@@ -25,6 +25,7 @@ npx doc-sync-check <source-dir> --docs <docs-dir>
 ### Options
 - `<source-dir>`: The root directory containing your TypeScript files.
 - `--docs, -d`: The path to the folder containing your Markdown documentation files. Defaults to `./docs`.
+- `--include, -i`: One or more glob patterns for documentation files. Overrides `--docs`.
 - `--strict, -s`: If set, the CLI will exit with code 1 if any documentation drift is detected. Defaults to `false`.
 
 ### Example
@@ -32,11 +33,19 @@ npx doc-sync-check <source-dir> --docs <docs-dir>
 npx doc-sync-check src --docs docs
 ```
 
+```bash
+npx doc-sync-check src --include "docs/**/*.md" "README.md" --strict
+```
+
 ## 🧠 How it Works
 
-1. **Extraction**: Parsers comb through your target TypeScript directory looking for exported functions.
-2. **Analysis**: The script breaks apart definitions into precise semantic substrings (e.g. tracking `userAuth(uuid: string, options?: any): boolean | void`).
-3. **Drift Detection**: Any Markdown file mentioning a detected function name by exact match must also include its corresponding up-to-date signature. If it doesn't, the CLI flags a drift warning. If the `--strict` flag is used, it also fails the process (Exit Code 1).
+1. **Extraction**: The parser walks your TypeScript AST and extracts exported symbols:
+   - exported functions
+   - exported interfaces (including property/method types)
+   - exported classes and class methods (excluding private methods)
+   - exported type aliases
+2. **Normalization**: Signatures are converted to single-line forms so multiline declarations still match docs reliably.
+3. **Drift Detection**: Any Markdown file mentioning a detected symbol by exact name should include the up-to-date signature. Missing or stale signatures are flagged. With `--strict`, drift returns exit code `1`.
 
 ## 🤝 Contributing
 

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -1,13 +1,70 @@
 import { parse } from '@babel/parser';
 import * as traverseModule from '@babel/traverse';
 import type { NodePath } from '@babel/traverse';
-import type { ExportNamedDeclaration, FunctionDeclaration, Node } from '@babel/types';
+import type {
+  ClassBody,
+  ClassMethod,
+  ClassPrivateMethod,
+  Expression,
+  ExportDefaultDeclaration,
+  ExportNamedDeclaration,
+  FunctionDeclaration,
+  Identifier,
+  Node,
+  PrivateName,
+  TSDeclareMethod,
+  TSInterfaceBody,
+  TSInterfaceDeclaration,
+  TSMethodSignature,
+  TSPropertySignature,
+  TSTypeAliasDeclaration,
+} from '@babel/types';
 
 type NodeWithSpan = Node & { start: number | null; end: number | null };
+type MaybeTraverse = { default?: unknown; traverse?: unknown };
+
+const normalizeSpace = (value: string): string => value.replace(/\s+/g, ' ').trim();
 
 const sliceSpan = (node: NodeWithSpan, source: string): string => {
   if (node.start == null || node.end == null) return '';
-  return source.slice(node.start, node.end);
+  return normalizeSpace(source.slice(node.start, node.end));
+};
+
+const keyName = (key: Identifier | PrivateName): string => {
+  if (key.type === 'Identifier') return key.name;
+  return key.id.name;
+};
+
+const typeParamsText = (node: { typeParameters?: Node | null }, source: string): string => {
+  if (!node.typeParameters) return '';
+  return sliceSpan(node.typeParameters as NodeWithSpan, source);
+};
+
+const typeAnnotationText = (
+  node: { typeAnnotation?: Node | null; returnType?: Node | null },
+  source: string,
+): string => {
+  if (node.typeAnnotation) return sliceSpan(node.typeAnnotation as NodeWithSpan, source);
+  if (node.returnType) return sliceSpan(node.returnType as NodeWithSpan, source);
+  return '';
+};
+
+const decoratorsText = (node: { decorators?: Node[] | null }, source: string): string => {
+  if (!node.decorators || node.decorators.length === 0) return '';
+  const text = node.decorators.map((decorator) => sliceSpan(decorator as NodeWithSpan, source)).join(' ');
+  return text ? `${text} ` : '';
+};
+
+const methodParams = (params: Node[], source: string): string[] =>
+  params.map((param) => sliceSpan(param as NodeWithSpan, source));
+
+const hasIdentifierKey = (key: Expression | Identifier | PrivateName): key is Identifier =>
+  key.type === 'Identifier';
+
+const shouldSkipClassMember = (member: ClassMethod | TSDeclareMethod | ClassPrivateMethod): boolean => {
+  if (member.type === 'ClassPrivateMethod') return true;
+  if ('accessibility' in member && member.accessibility === 'private') return true;
+  return false;
 };
 
 export interface FunctionSignature {
@@ -19,7 +76,6 @@ export interface FunctionSignature {
 
 export function extractSignatures(code: string): FunctionSignature[] {
   const signatures: FunctionSignature[] = [];
-  type MaybeTraverse = { default?: unknown; traverse?: unknown };
   const moduleCandidate = traverseModule as unknown as MaybeTraverse;
   const candidates = [
     moduleCandidate.default && (moduleCandidate.default as { default?: unknown }).default,
@@ -35,40 +91,130 @@ export function extractSignatures(code: string): FunctionSignature[] {
     console.error('Parsing error: traverse not available');
     return signatures;
   }
-  
+
+  const addSignature = (
+    name: string,
+    parameters: string[],
+    returnType: string,
+    prefix = '',
+    annotations = '',
+  ): void => {
+    const normalizedReturn = normalizeSpace(returnType);
+    const combined = `${annotations}${prefix}${name}(${parameters.join(', ')})${normalizedReturn}`;
+    signatures.push({
+      name,
+      parameters,
+      returnType: normalizedReturn,
+      fullSignature: normalizeSpace(combined),
+    });
+  };
+
+  const addInterfaceSignatures = (declaration: TSInterfaceDeclaration): void => {
+    const ifaceName = `${declaration.id.name}${typeParamsText(declaration, code)}`;
+    const body = declaration.body as TSInterfaceBody;
+    const props: string[] = [];
+
+    body.body.forEach((member) => {
+      if (member.type === 'TSPropertySignature') {
+        const property = member as TSPropertySignature;
+        if (!hasIdentifierKey(property.key)) return;
+        const optional = property.optional ? '?' : '';
+        const propertyType = typeAnnotationText(property as unknown as { typeAnnotation?: Node | null }, code);
+        props.push(`${property.key.name}${optional}${propertyType}`);
+      }
+
+      if (member.type === 'TSMethodSignature') {
+        const method = member as TSMethodSignature;
+        if (!hasIdentifierKey(method.key)) return;
+        const optional = method.optional ? '?' : '';
+        const params = methodParams(method.parameters as unknown as Node[], code);
+        const returnType = typeAnnotationText(method as unknown as { typeAnnotation?: Node | null }, code);
+        props.push(`${method.key.name}${optional}(${params.join(', ')})${returnType}`);
+      }
+    });
+
+    signatures.push({
+      name: declaration.id.name,
+      parameters: props,
+      returnType: '',
+      fullSignature: normalizeSpace(`interface ${ifaceName} { ${props.join('; ')} }`),
+    });
+  };
+
+  const addClassSignatures = (className: string, body: ClassBody): void => {
+    body.body.forEach((member) => {
+      if (member.type !== 'ClassMethod' && member.type !== 'TSDeclareMethod') return;
+      if (shouldSkipClassMember(member)) return;
+      if (member.kind === 'constructor' || member.kind === 'get' || member.kind === 'set') return;
+      if (!hasIdentifierKey(member.key)) return;
+
+      const params = methodParams(member.params as Node[], code);
+      const returnType = typeAnnotationText(member as unknown as { returnType?: Node | null }, code);
+      const annotations = decoratorsText(member as unknown as { decorators?: Node[] | null }, code);
+      addSignature(`${className}.${keyName(member.key)}`, params, returnType, '', annotations);
+    });
+  };
+
+  const handleDeclaration = (declaration: Node | null | undefined): void => {
+    if (!declaration) return;
+
+    if (declaration.type === 'FunctionDeclaration') {
+      const fnDecl = declaration as FunctionDeclaration;
+      addSignature(
+        fnDecl.id?.name ?? 'anonymous',
+        methodParams(fnDecl.params as Node[], code),
+        typeAnnotationText(fnDecl as unknown as { returnType?: Node | null }, code),
+      );
+      return;
+    }
+
+    if (declaration.type === 'TSInterfaceDeclaration') {
+      addInterfaceSignatures(declaration as TSInterfaceDeclaration);
+      return;
+    }
+
+    if (declaration.type === 'ClassDeclaration' && declaration.id) {
+      const className = `${declaration.id.name}${typeParamsText(declaration, code)}`;
+      const annotations = decoratorsText(declaration as unknown as { decorators?: Node[] | null }, code);
+      signatures.push({
+        name: declaration.id.name,
+        parameters: [],
+        returnType: '',
+        fullSignature: normalizeSpace(`${annotations}class ${className}`),
+      });
+      addClassSignatures(declaration.id.name, declaration.body);
+      return;
+    }
+
+    if (declaration.type === 'TSTypeAliasDeclaration') {
+      const typeDecl = declaration as TSTypeAliasDeclaration;
+      const typeName = `${typeDecl.id.name}${typeParamsText(typeDecl, code)}`;
+      const rhs = sliceSpan(typeDecl.typeAnnotation as NodeWithSpan, code);
+      signatures.push({
+        name: typeDecl.id.name,
+        parameters: [],
+        returnType: '',
+        fullSignature: normalizeSpace(`type ${typeName} = ${rhs}`),
+      });
+    }
+  };
+
   try {
     const ast = parse(code, {
-      sourceType: "module",
-      plugins: ["typescript"]
+      sourceType: 'module',
+      plugins: ['typescript', 'decorators-legacy'],
     });
 
     traverse(ast, {
       ExportNamedDeclaration(path: NodePath<ExportNamedDeclaration>) {
-        const { declaration } = path.node;
-        
-        if (declaration && declaration.type === 'FunctionDeclaration') {
-          const fnDecl = declaration as FunctionDeclaration;
-          const name = fnDecl.id?.name ?? 'anonymous';
-          
-          const parameters = fnDecl.params.map((param) => sliceSpan(param as NodeWithSpan, code));
-
-          const returnType = fnDecl.returnType
-            ? sliceSpan(fnDecl.returnType as unknown as NodeWithSpan, code)
-            : '';
-
-          const fullSignature = `${name}(${parameters.join(', ')})${returnType}`;
-
-          signatures.push({
-            name,
-            parameters,
-            returnType,
-            fullSignature,
-          });
-        }
-      }
+        handleDeclaration(path.node.declaration);
+      },
+      ExportDefaultDeclaration(path: NodePath<ExportDefaultDeclaration>) {
+        handleDeclaration(path.node.declaration as Node);
+      },
     });
-  } catch (e) {
-    console.error("Parsing error:", e);
+  } catch (error) {
+    console.error('Parsing error:', error);
   }
 
   return signatures;

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -1,26 +1,104 @@
 import { extractSignatures } from '../src/extractor.js';
 
 describe('AST Extractor', () => {
-  it('should correctly extract function name and parameters', () => {
+  it('extracts exported function signatures with normalized spacing', () => {
     const code = `
-      export function testAuth(token: string, options?: any): boolean {
+      export function testAuth(
+        token: string,
+        options?: any
+      ): boolean {
         return true;
       }
     `;
+
     const signatures = extractSignatures(code);
     expect(signatures).toHaveLength(1);
     expect(signatures[0].name).toBe('testAuth');
     expect(signatures[0].parameters).toEqual(['token: string', 'options?: any']);
     expect(signatures[0].returnType).toBe(': boolean');
+    expect(signatures[0].fullSignature).toBe('testAuth(token: string, options?: any): boolean');
   });
 
-  it('should correctly assemble the full signature string', () => {
+  it('extracts exported interfaces and includes property types', () => {
     const code = `
-      export function getUser(id: number): any {
-        return { name: "Test" };
+      export interface User<TMeta = string> {
+        id: number;
+        name?: string;
+        serialize(format: 'json' | 'text'): string;
       }
     `;
+
     const signatures = extractSignatures(code);
-    expect(signatures[0].fullSignature).toBe('getUser(id: number): any');
+    expect(signatures).toHaveLength(1);
+    expect(signatures[0].name).toBe('User');
+    expect(signatures[0].fullSignature).toContain('interface User<TMeta = string>');
+    expect(signatures[0].fullSignature).toContain('id: number');
+    expect(signatures[0].fullSignature).toContain("serialize(format: 'json' | 'text'): string");
+  });
+
+  it('extracts exported classes and skips private methods', () => {
+    const code = `
+      export class SessionManager<TContext> {
+        private secret(v: string): void {}
+        public create(id: string): Promise<void> { return Promise.resolve(); }
+      }
+    `;
+
+    const signatures = extractSignatures(code);
+    const full = signatures.map((sig) => sig.fullSignature);
+    expect(full).toContain('class SessionManager<TContext>');
+    expect(full).toContain('SessionManager.create(id: string): Promise<void>');
+    expect(full.join(' ')).not.toContain('secret');
+  });
+
+  it('extracts overload and abstract class methods', () => {
+    const code = `
+      export abstract class Repo {
+        abstract find(id: string): Promise<string>;
+        find(id: number): Promise<string>;
+        find(id: string | number): Promise<string> {
+          return Promise.resolve(String(id));
+        }
+      }
+    `;
+
+    const signatures = extractSignatures(code).map((sig) => sig.fullSignature);
+    expect(signatures).toContain('Repo.find(id: string): Promise<string>');
+    expect(signatures).toContain('Repo.find(id: number): Promise<string>');
+    expect(signatures).toContain('Repo.find(id: string | number): Promise<string>');
+  });
+
+  it('parses decorators and preserves decorator metadata in signatures', () => {
+    const code = `
+      function sealed(target: unknown): void {}
+      function auditable(): MethodDecorator { return () => undefined; }
+
+      @sealed
+      export class BillingService {
+        @auditable()
+        public charge(amount: number): Promise<boolean> {
+          return Promise.resolve(true);
+        }
+      }
+    `;
+
+    const signatures = extractSignatures(code).map((sig) => sig.fullSignature);
+    expect(signatures).toContain('@sealed class BillingService');
+    expect(signatures).toContain('@auditable() BillingService.charge(amount: number): Promise<boolean>');
+  });
+
+  it('extracts exported type aliases including generics', () => {
+    const code = `
+      export type ApiResponse<T> = {
+        data: T;
+        error?: string;
+      };
+    `;
+
+    const signatures = extractSignatures(code);
+    expect(signatures).toHaveLength(1);
+    expect(signatures[0].name).toBe('ApiResponse');
+    expect(signatures[0].fullSignature).toContain('type ApiResponse<T> =');
+    expect(signatures[0].fullSignature).toContain('data: T');
   });
 });


### PR DESCRIPTION
This PR prepares the 1.2.0 milestone release with AST coverage expansion and docs updates.

Included changes:
- exported interface extraction with property and method signatures
- exported class extraction with class methods, overload support, abstract method handling, and private method filtering
- exported type alias extraction with generics support
- decorator metadata parsing in extracted class/method signatures
- multiline signature normalization for stable drift comparisons
- README and changelog updates for 1.2.0 behavior

Issue mapping (auto-close on merge):
Closes #18
Closes #19
Closes #20
Closes #21
Closes #22
Closes #23
Closes #24
Closes #25
Closes #26
Closes #27
Closes #50
Closes #69