### PR TITLE
chore(ci): auto-enable GitHub Pages before deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@v4
         with:
           path: website


### PR DESCRIPTION
## Summary
- fix Pages workflow failure on repositories where Pages is not pre-enabled
- set enablement true in actions/configure-pages@v5

## Why
The merge to main failed with:
- Get Pages site failed ... Not Found

This allows the workflow to bootstrap Pages instead of failing on first run.
