### PR TITLE
ci: skip pages deploy when pages is disabled

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@v4
         with:
           path: website

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,12 +14,11 @@ permissions:
 
 jobs:
   deploy:
+    if: ${{ github.event.repository.has_pages }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/configure-pages@v5
-        with:
-          enablement: true
       - uses: actions/upload-pages-artifact@v4
         with:
           path: website


### PR DESCRIPTION
## Summary
- fix Pages workflow failure caused by missing permission to auto-create a Pages site
- deploy job now runs only when repository Pages is already enabled

## Why
GitHub Actions token cannot create a Pages site in this repo context.
This change prevents failures on main until Pages is enabled in repository settings.
