### PR TITLE
feat: load config file, harden CLI, and fix inference and deprecated-doc bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,80 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 1.6.0 (2026-07-16)
+
+### Features
+
+- load `.doc-sync-checkrc.json` automatically and add a `--config` flag for a custom path; command-line flags override the config file, which overrides the built-in defaults
+
+### Bug Fixes
+
+- exclude `return` statements inside nested function scopes when inferring a function's return type (follow-up to #35)
+- match deprecated symbols documented without the `[deprecated]` marker, removing false drift and unused-doc-block reports (follow-up to #33)
+- exit with a non-zero code when the CLI fails with an unexpected error
+
+### Documentation
+
+- document the configuration file and `--config` flag
+
+## 1.5.0 (2026-06-21)
+
+### Features
+
+- improve npm and GitHub discoverability metadata (#117)
+
+### Tests
+
+- add regression tests for markdown signature normalization (#96, #118)
+
+## 1.4.0 (2026-05-24)
+
+### Features
+
+- add JavaScript and JSDoc parsing support in the extractor pipeline (#51)
+- export AST logic via the `src/ast/` entrypoint to decouple it from the CLI (#48)
+- add Sonar and Cobertura coverage export formats (#47)
+- add incremental scan caching via `.doc-sync-cache.json` (#46)
+- add Slack and Discord webhook notifications on drift failures (#45)
+- add the `--init` setup command for first-time users (#44)
+- scan TS/JS trees and retain imported type names in signatures (#43)
+- add `--fix-docs` auto-normalization for inline signature formatting (#42)
+- add Docusaurus/VuePress markdown pattern defaults (#40)
+- automate the README signature section via `--update-readme` markers (#39)
+- add optional JSDoc description synchronization checks via `--check-descriptions` (#38)
+
+### Documentation
+
+- add a website scaffold with a GitHub Pages workflow (#54)
+- add a VSCode extension scaffold (#41)
+
+## 1.3.0 (2026-05-01)
+
+### Features
+
+- support namespace exports (#37)
+- detect unused documentation blocks (#36)
+- infer return types when no explicit annotation is present (#35)
+- support enums and constant values (#34)
+- detect and flag deprecated symbols (#33)
+- generate a documentation coverage badge (#32)
+- support union and intersection types (#31)
+- handle rest parameters (#30)
+- validate optional versus required parameters (#29)
+- compare parameter default values (#28)
+
+### Bug Fixes
+
+- resolve duplicate function names across namespaces (#56)
+
+### Performance
+
+- switch to the SWC parser for faster execution (#53)
+
+### Documentation
+
+- add contribution guidelines for AST changes (#49)
+
 ## 1.2.0 (2026-04-22)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -33,8 +33,25 @@ npx doc-sync-check <source-dir> --docs <docs-dir>
 - `--fix-docs`: Auto-trims inline markdown signature blocks.
 - `--check-descriptions`: Compares JSDoc descriptions against markdown text.
 - `--update-readme`: Updates function list between README markers.
-- `--init`: Creates a starter `.doc-sync-checkrc.json`.
+- `--config`: Path to the config file (default: `.doc-sync-checkrc.json`).
+- `--init`: Writes a starter `.doc-sync-checkrc.json`.
 - `--slack-webhook` and `--discord-webhook`: Sends drift failure notifications.
+
+### Configuration file
+
+If a `.doc-sync-checkrc.json` file is present (or one is passed via `--config`), its
+values are loaded automatically. Explicit command-line flags always take precedence
+over the config file, which in turn takes precedence over the built-in defaults.
+
+```json
+{
+  "include": ["docs/**/*.md", "README.md"],
+  "strict": true,
+  "cache": true,
+  "coverageOut": "./coverage/doc-coverage.json",
+  "coverageFormat": "json"
+}
+```
 
 ### Example
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-sync-check",
-  "version": "1.1.0",
+  "version": "1.6.0",
   "description": "Documentation Drift Detector",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
 import { contentHash, DEFAULT_CACHE_PATH, loadCache, saveCache } from './cache.js';
 import { notifyDriftFailure } from './integrations.js';
 import { updateReadmeFunctions } from './readme.js';
+import { DEFAULT_CONFIG_PATH, loadFileConfig, type FileConfig } from './config.js';
 
 const cli = meow(
   `
@@ -33,7 +34,8 @@ const cli = meow(
 	  --check-descriptions  Validate JSDoc descriptions appear in docs
 	  --update-readme       Auto-write exported signatures to README markers
 	  --readme-path         README path for --update-readme (default: ./README.md)
-	  --init                Interactive setup wizard
+	  --config              Config file path (default: .doc-sync-checkrc.json)
+	  --init                Write a starter .doc-sync-checkrc.json
 
 	Examples
 	  $ doc-sync-check src --docs ./documentation --strict
@@ -55,13 +57,27 @@ const cli = meow(
       checkDescriptions: { type: 'boolean', default: false },
       updateReadme: { type: 'boolean', default: false },
       readmePath: { type: 'string', default: './README.md' },
+      config: { type: 'string', default: DEFAULT_CONFIG_PATH },
       init: { type: 'boolean', default: false },
     },
   },
 );
 
-async function runInitWizard(): Promise<void> {
-  const configPath = '.doc-sync-checkrc.json';
+// meow always supplies defaults, so we inspect argv to tell an explicitly
+// passed flag from a default. Explicit flags win over the config file.
+const flagWasProvided = (name: string, shortFlag?: string): boolean => {
+  const kebab = name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+  return process.argv.slice(2).some((token) =>
+    token === `--${kebab}` ||
+    token.startsWith(`--${kebab}=`) ||
+    token === `--no-${kebab}` ||
+    token === `--${name}` ||
+    token.startsWith(`--${name}=`) ||
+    (!!shortFlag && (token === `-${shortFlag}` || token.startsWith(`-${shortFlag}=`))),
+  );
+};
+
+async function runInitWizard(configPath: string): Promise<void> {
   const template = {
     docs: './docs',
     include: ['docs/**/*.md', 'README.md', 'website/docs/**/*.md'],
@@ -96,7 +112,7 @@ const normalizeDocBlocks = async (docPatterns: string[]): Promise<void> => {
 
 async function run() {
   if (cli.flags.init) {
-    await runInitWizard();
+    await runInitWizard(cli.flags.config);
     return;
   }
 
@@ -106,23 +122,48 @@ async function run() {
     process.exit(1);
   }
 
+  const fileConfig = await loadFileConfig(cli.flags.config);
+  const resolve = <K extends keyof typeof cli.flags & keyof FileConfig>(
+    key: K,
+    shortFlag?: string,
+  ): NonNullable<FileConfig[K]> => {
+    if (flagWasProvided(key, shortFlag) || fileConfig[key] === undefined) {
+      return cli.flags[key] as NonNullable<FileConfig[K]>;
+    }
+    return fileConfig[key] as NonNullable<FileConfig[K]>;
+  };
+
+  const docs = resolve('docs', 'd');
+  const include = resolve('include', 'i');
+  const strict = resolve('strict', 's');
+  const useCache = resolve('cache');
+  const cacheFile = resolve('cacheFile');
+  const coverageOut = resolve('coverageOut');
+  const coverageFormat = resolve('coverageFormat');
+  const slackWebhook = resolve('slackWebhook');
+  const discordWebhook = resolve('discordWebhook');
+  const fixDocs = resolve('fixDocs');
+  const checkDescriptions = resolve('checkDescriptions');
+  const updateReadme = resolve('updateReadme');
+  const readmePath = resolve('readmePath');
+
   const docPatterns =
-    cli.flags.include && cli.flags.include.length > 0
-      ? cli.flags.include
+    include && include.length > 0
+      ? include
       : [
-          path.join(cli.flags.docs as string, '**/*.md'),
+          path.join(docs, '**/*.md'),
           'README.md',
           'website/docs/**/*.md',
           'docs/**/*.md',
           '.vuepress/**/*.md',
         ];
 
-  if (cli.flags.fixDocs) {
+  if (fixDocs) {
     await normalizeDocBlocks(docPatterns);
   }
 
   const files = await parseSourceFiles(sourceDir);
-  const cache = cli.flags.cache ? await loadCache(cli.flags.cacheFile) : { version: 1 as const, files: {} };
+  const cache = useCache ? await loadCache(cacheFile) : { version: 1 as const, files: {} };
   const nextCache = { version: 1 as const, files: { ...cache.files } };
   const allSigs = [];
 
@@ -132,7 +173,7 @@ async function run() {
     const hash = contentHash(code);
     const cached = cache.files[file];
 
-    if (cli.flags.cache && cached && cached.mtimeMs === stat.mtimeMs && cached.hash === hash) {
+    if (useCache && cached && cached.mtimeMs === stat.mtimeMs && cached.hash === hash) {
       allSigs.push(...cached.signatures);
       continue;
     }
@@ -143,31 +184,28 @@ async function run() {
     nextCache.files[file] = { mtimeMs: stat.mtimeMs, hash, signatures: sigs };
   }
 
-  if (cli.flags.cache) {
-    await saveCache(cli.flags.cacheFile, nextCache);
+  if (useCache) {
+    await saveCache(cacheFile, nextCache);
   }
 
-  if (cli.flags.updateReadme) {
-    await updateReadmeFunctions(cli.flags.readmePath, allSigs);
+  if (updateReadme) {
+    await updateReadmeFunctions(readmePath, allSigs);
   }
 
-  const result = await checkDrift(allSigs, docPatterns, {
-    checkDescriptions: cli.flags.checkDescriptions,
-  });
+  const result = await checkDrift(allSigs, docPatterns, { checkDescriptions });
 
   console.log(`\n📈 Coverage: ${result.coveragePercent}% documented (${result.documentedSymbols}/${allSigs.length})`);
 
-  if (cli.flags.coverageOut) {
-    const format = String(cli.flags.coverageFormat);
-    if (format === 'sonar') await writeSonarReport(result, cli.flags.coverageOut);
-    else if (format === 'cobertura') await writeCoberturaReport(result, cli.flags.coverageOut);
-    else await writeCoverageBadge(result, cli.flags.coverageOut);
+  if (coverageOut) {
+    if (coverageFormat === 'sonar') await writeSonarReport(result, coverageOut);
+    else if (coverageFormat === 'cobertura') await writeCoberturaReport(result, coverageOut);
+    else await writeCoverageBadge(result, coverageOut);
   }
 
   if (result.hasDrift) {
     await notifyDriftFailure({
-      slackWebhook: cli.flags.slackWebhook,
-      discordWebhook: cli.flags.discordWebhook,
+      slackWebhook,
+      discordWebhook,
       project: path.basename(process.cwd()),
       driftedSymbols: result.driftedSymbols,
       undocumentedSymbols: result.undocumentedSymbols,
@@ -175,7 +213,7 @@ async function run() {
       coveragePercent: result.coveragePercent,
     });
 
-    if (cli.flags.strict) {
+    if (strict) {
       console.error('\n❌ Drift check failed. Please update your documentation.');
       process.exit(1);
     }
@@ -186,4 +224,7 @@ async function run() {
   }
 }
 
-run();
+run().catch((error) => {
+  console.error('doc-sync-check failed:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,30 @@
+import fs from 'fs-extra';
+
+export interface FileConfig {
+  docs?: string;
+  include?: string[];
+  strict?: boolean;
+  cache?: boolean;
+  cacheFile?: string;
+  coverageOut?: string;
+  coverageFormat?: string;
+  slackWebhook?: string;
+  discordWebhook?: string;
+  fixDocs?: boolean;
+  checkDescriptions?: boolean;
+  updateReadme?: boolean;
+  readmePath?: string;
+}
+
+export const DEFAULT_CONFIG_PATH = '.doc-sync-checkrc.json';
+
+export async function loadFileConfig(configPath: string = DEFAULT_CONFIG_PATH): Promise<FileConfig> {
+  if (!(await fs.pathExists(configPath))) return {};
+  try {
+    const parsed: unknown = JSON.parse(await fs.readFile(configPath, 'utf-8'));
+    return parsed && typeof parsed === 'object' ? (parsed as FileConfig) : {};
+  } catch {
+    console.warn(`⚠️  Ignoring malformed config file: ${configPath}`);
+    return {};
+  }
+}

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -1,9 +1,8 @@
 import { parseSync } from '@swc/core';
+import { escapeRegExp, normalizeSpace } from './utils.js';
 
 type Span = { start: number; end: number };
 type AstNode = { type?: string; span?: Span; [key: string]: unknown };
-
-const normalizeSpace = (value: string): string => value.replace(/\s+/g, ' ').trim();
 
 const sliceSpan = (span: Span | undefined, source: string): string => {
   if (!span) return '';
@@ -35,8 +34,21 @@ const inferReturnType = (fn: AstNode | undefined): string => {
     else if (node.type === 'ObjectExpression') kinds.add('Record<string, unknown>');
     else kinds.add('unknown');
   };
+  // Returns inside nested functions belong to those scopes, not the one we
+  // are inferring, so we stop descending when we enter a new function scope.
+  const nestedScopes = new Set([
+    'FunctionDeclaration',
+    'FunctionExpression',
+    'ArrowFunctionExpression',
+    'ClassMethod',
+    'PrivateMethod',
+    'MethodProperty',
+    'GetterProperty',
+    'SetterProperty',
+  ]);
   const visit = (node: AstNode | undefined): void => {
     if (!node) return;
+    if (node.type && nestedScopes.has(node.type)) return;
     if (node.type === 'ReturnStatement') {
       const arg = node.argument as AstNode | undefined;
       if (!arg) {
@@ -117,7 +129,6 @@ const decoratorsText = (node: AstNode, source: string): string => {
 
 const formatDeprecated = (deprecated: boolean, signature: string): string =>
   deprecated ? `[deprecated] ${signature}` : signature;
-const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 export interface FunctionSignature {
   name: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ export * from './validator.js';
 export * from './ast/index.js';
 export * from './cache.js';
 export * from './integrations.js';
+export * from './config.js';
+export * from './utils.js';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,10 @@
+export const normalizeSpace = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+export const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const DEPRECATED_MARKER = '[deprecated] ';
+
+// The extractor prepends this marker to deprecated signatures; strip it so
+// signature comparison ignores deprecation status.
+export const stripDeprecatedMarker = (signature: string): string =>
+  signature.startsWith(DEPRECATED_MARKER) ? signature.slice(DEPRECATED_MARKER.length) : signature;

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -2,12 +2,7 @@ import { globby } from 'globby';
 import fs from 'fs-extra';
 import path from 'path';
 import type { FunctionSignature } from './extractor.js';
-
-function normalizeSpace(str: string): string {
-  return str.replace(/\s+/g, ' ').trim();
-}
-
-const escapeLiteral = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+import { escapeRegExp, normalizeSpace, stripDeprecatedMarker } from './utils.js';
 
 const signatureLiterals = (content: string): string[] => {
   const matches = content.match(/`([^`]+)`/g) ?? [];
@@ -73,11 +68,15 @@ export async function checkDrift(
     doc.signatureBlocks.forEach((block) => allDocSignatureBlocks.add(block));
   });
 
-  const knownSignatureBlocks = new Set<string>(signatures.map((sig) => normalizeSpace(sig.fullSignature)));
+  // Docs are not expected to carry the extractor's [deprecated] marker, so we
+  // compare against the marker-free form on both sides.
+  const knownSignatureBlocks = new Set<string>(
+    signatures.map((sig) => stripDeprecatedMarker(normalizeSpace(sig.fullSignature))),
+  );
 
   for (const sig of signatures) {
-    const normalizedSig = normalizeSpace(sig.fullSignature);
-    const nameRegex = new RegExp(`\\b${escapeLiteral(sig.name)}\\b`);
+    const normalizedSig = stripDeprecatedMarker(normalizeSpace(sig.fullSignature));
+    const nameRegex = new RegExp(`\\b${escapeRegExp(sig.name)}\\b`);
     let nameFound = false;
     let signatureFound = false;
 
@@ -95,7 +94,7 @@ export async function checkDrift(
 
     if (nameFound && !signatureFound) {
       console.error(`❌ DRIFT DETECTED: Symbol '${sig.name}' is mentioned in documentation, but the updated signature was not found.`);
-      console.error(`   Expected to find: ${sig.fullSignature}`);
+      console.error(`   Expected to find: ${normalizedSig}`);
       hasDrift = true;
       driftedSymbols += 1;
     } else if (nameFound && signatureFound) {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+import fs from 'fs-extra';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { loadFileConfig } from '../src/config.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('loadFileConfig', () => {
+  const tempDir = path.join(__dirname, 'temp_config');
+
+  beforeEach(async () => {
+    await fs.ensureDir(tempDir);
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  it('returns an empty object when the config file is absent', async () => {
+    const result = await loadFileConfig(path.join(tempDir, 'missing.json'));
+    expect(result).toEqual({});
+  });
+
+  it('parses a valid config file', async () => {
+    const configPath = path.join(tempDir, 'rc.json');
+    await fs.writeFile(configPath, JSON.stringify({ strict: true, include: ['docs/**/*.md'] }));
+    const result = await loadFileConfig(configPath);
+    expect(result).toEqual({ strict: true, include: ['docs/**/*.md'] });
+  });
+
+  it('ignores a malformed config file instead of throwing', async () => {
+    const configPath = path.join(tempDir, 'bad.json');
+    await fs.writeFile(configPath, '{ not valid json ');
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await loadFileConfig(configPath);
+    expect(result).toEqual({});
+    warn.mockRestore();
+  });
+});

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -58,6 +58,18 @@ describe('AST Extractor (1.3.0 scope)', () => {
     expect(signatures[0].returnType).toBe(': number | string');
   });
 
+  it('ignores returns from nested function scopes when inferring return type', () => {
+    const code = `
+      export function outer(flag: boolean) {
+        const cb = () => { return 'nested'; };
+        function helper() { return false; }
+        return 1;
+      }
+    `;
+    const signatures = extractSignatures(code);
+    expect(signatures[0].returnType).toBe(': number');
+  });
+
   it('marks deprecated symbols using JSDoc tags', () => {
     const code = `
       /** @deprecated use \`next\` */

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -67,6 +67,24 @@ describe('Validator (1.3.0 scope)', () => {
     expect(result.unusedDocBlocks).toContain('removedFn(x: string): boolean');
   });
 
+  it('treats a deprecated symbol as in sync when docs omit the [deprecated] marker', async () => {
+    const sigs: FunctionSignature[] = [
+      {
+        name: 'legacy',
+        parameters: ['value: string'],
+        returnType: ': string',
+        fullSignature: '[deprecated] legacy(value: string): string',
+      },
+    ];
+    await fs.writeFile(path.join(tempDocsDir, 'docs.md'), 'Use `legacy(value: string): string` for now.');
+
+    const result = await checkDrift(sigs, path.join(tempDocsDir, '**/*.md'));
+
+    expect(result.hasDrift).toBe(false);
+    expect(result.inSyncSymbols).toBe(1);
+    expect(result.unusedDocBlocks).toEqual([]);
+  });
+
   it('normalizes whitespace inside inline code signatures before comparing', async () => {
     const sigs: FunctionSignature[] = [
       {


### PR DESCRIPTION
## Summary

Improvements to doc-sync-check found while reviewing the codebase. All changes
build, lint, typecheck, and pass tests locally.

## Features
- Load `.doc-sync-checkrc.json` automatically and add a `--config` flag for a
  custom path. Precedence: explicit CLI flags over config file over defaults.
  The config file was previously written by `--init` but never read.

## Bug fixes
- Return-type inference no longer descends into nested function scopes, so a
  `return` inside a callback or inner function stops leaking into the outer
  signature (follow-up to #35).
- Deprecated symbols documented without the `[deprecated]` marker are now
  matched correctly, removing false drift and unused-doc-block reports
  (follow-up to #33).
- The CLI now exits with a non-zero code on an unexpected error.

## Housekeeping
- Shared `normalizeSpace` and `escapeRegExp` helpers extracted into `src/utils.ts`.
- Changelog backfilled for 1.3.0 through 1.6.0 (it had drifted to 1.2.0), and
  `package.json` version aligned to 1.6.0.

## Notes
- On merge to `main`, semantic-release will cut the release. The commits are a
  `feat` plus `fix`es, so the next version is 1.6.0.
- Tests added: nested-scope return inference, deprecated in-sync matching, and
  config loading (present, absent, malformed).
