### PR TITLE
chore(deps): add 7-day cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

Add a 7-day cooldown to both Dependabot update ecosystems (npm and
github-actions) via cooldown.default-days: 7.

## Why

Dependabot will hold a newly published version for 7 days before opening an
update PR. This avoids churn from same-week patch re-releases and gives new
releases time to have regressions or supply-chain issues reported before they
land here.

## Scope

- default-days applies to all update types (major, minor, patch).
- No release impact: this is a chore change, so semantic-release will not cut
  a version.
