### PR TITLE
chore(deps): split dependabot cooldown by semver bump type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 14
     commit-message:
       prefix: "chore(deps)"
   - package-ecosystem: "github-actions"
@@ -14,5 +17,8 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 14
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

Replace the flat 7-day Dependabot cooldown with a per-bump-type split for both
the npm and github-actions ecosystems:

- semver-patch-days: 3
- semver-minor-days: 7
- semver-major-days: 14
- default-days: 7 (fallback)

## Why

Cooldown cannot key on CVE severity, and it does not apply to security updates
at all, so vulnerability fixes are never delayed by it. Splitting by bump type
is the supported way to differentiate risk: patch bumps soak briefly, majors
soak longer to reduce churn and give regressions time to surface.
