### PR TITLE
chore(deps): group dependabot updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       semver-patch-days: 3
       semver-minor-days: 7
       semver-major-days: 14
+    groups:
+      npm-version-updates:
+        applies-to: version-updates
+        patterns: ["*"]
+      npm-security-updates:
+        applies-to: security-updates
+        patterns: ["*"]
     commit-message:
       prefix: "chore(deps)"
   - package-ecosystem: "github-actions"
@@ -20,5 +27,12 @@ updates:
       semver-patch-days: 3
       semver-minor-days: 7
       semver-major-days: 14
+    groups:
+      actions-version-updates:
+        applies-to: version-updates
+        patterns: ["*"]
+      actions-security-updates:
+        applies-to: security-updates
+        patterns: ["*"]
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

Add Dependabot `groups` so updates are combined into single pull requests
instead of one PR per dependency, for both the npm and github-actions
ecosystems.

Each ecosystem gets two groups (patterns: ["*"], all dependencies):
- a version-updates group (default scope)
- a security-updates group (applies-to: security-updates)

Result: at most one version-update PR and one security-update PR per
ecosystem, rather than one per dependency. The existing severity-based
cooldown is unchanged.

## Tradeoff

If a single dependency in a grouped PR fails CI, the whole PR is blocked
until that update is resolved or excluded. This is the expected cost of
consolidating into fewer PRs.
