### PR TITLE
fix(dependabot): remove unsupported semver cooldown from github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,9 +24,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-patch-days: 3
-      semver-minor-days: 7
-      semver-major-days: 14
     groups:
       actions-version-updates:
         applies-to: version-updates


### PR DESCRIPTION
## Summary

The github-actions ecosystem only supports `default-days` in the `cooldown`
block; it does not accept `semver-patch-days`, `semver-minor-days`, or
`semver-major-days`. Those keys (added in the earlier severity-split change)
made the entire `.github/dependabot.yml` invalid, so Dependabot ignored the
whole config, including the `groups` block, and opened one pull request per
dependency.

This removes the unsupported keys from the github-actions block and keeps
`default-days: 7`. The npm block keeps the full semver cooldown split, which is
supported there. The groups (one version-updates group and one security-updates
group per ecosystem) are unchanged.

## Effect

Once merged, Dependabot re-reads a valid config and consolidates updates into a
single grouped pull request per ecosystem instead of one per dependency.
