### PR TITLE
chore(dependabot): ignore typescript major until ts-jest supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
       npm-security-updates:
         applies-to: security-updates
         patterns: ["*"]
+    ignore:
+      # ts-jest and typescript-eslint peer-require typescript < 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "chore(deps)"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

Ignore major-version updates for typescript in Dependabot. ts-jest and
typescript-eslint both peer-require typescript below 7, so a TypeScript 7 bump
breaks the test and lint toolchain.

This drops TypeScript 7 from the npm version-updates group, so the grouped PR
becomes installable and mergeable, and it stops Dependabot from re-proposing the
TypeScript 7 bump (closing that PR). Minor and patch TypeScript updates within
the 6.x line are still allowed.

Revisit once ts-jest and typescript-eslint publish releases that support
TypeScript 7.
