### PR TITLE
refactor: use shorol for dynamic regex construction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@swc/core": "^1.15.32",
         "fs-extra": "^11.3.6",
         "globby": "^16.2.0",
-        "meow": "^14.1.0"
+        "meow": "^14.1.0",
+        "shorol": "^2.1.8"
       },
       "bin": {
         "doc-sync-check": "dist/cli.js"
@@ -13240,6 +13241,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shorol": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/shorol/-/shorol-2.1.8.tgz",
+      "integrity": "sha512-B7GrN4dqPKGl0zSXQ6c0lPYXp0lWg1GW1Pp+vV4ll9cVU4yzgvxWk4dvd+2ZMp4sC+yU4i5XtV3cTZPDz98GWg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/signal-exit": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "@swc/core": "^1.15.32",
     "fs-extra": "^11.3.6",
     "globby": "^16.2.0",
-    "meow": "^14.1.0"
+    "meow": "^14.1.0",
+    "shorol": "^2.1.8"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.2.1",

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -1,5 +1,6 @@
 import { parseSync } from '@swc/core';
-import { escapeRegExp, normalizeSpace } from './utils.js';
+import { regex } from 'shorol';
+import { normalizeSpace } from './utils.js';
 
 type Span = { start: number; end: number };
 type AstNode = { type?: string; span?: Span; [key: string]: unknown };
@@ -331,9 +332,26 @@ export function extractSignatures(code: string, options: ExtractOptions = {}): F
     const params = (declaration.params as AstNode[] | undefined) ?? [];
     const parameterTexts = params.map((param) => getParamText(param, code));
     const explicitReturn = sliceSpan((declaration.returnType as AstNode | undefined)?.span, code);
-    const deprecated =
-      hasDeprecatedTag(declaration.span, code) ||
-      new RegExp(`/\\*\\*[\\s\\S]{0,500}@deprecated[\\s\\S]{0,500}\\*/\\s*export\\s+function\\s+${escapeRegExp(fnName)}\\b`, 'i').test(code);
+    const deprecatedBeforeFn = regex()
+      .literal('/**')
+      .any()
+      .repeat(0, 500)
+      .literal('@deprecated')
+      .any()
+      .repeat(0, 500)
+      .literal('*/')
+      .whitespace()
+      .zeroOrMore()
+      .literal('export')
+      .whitespace()
+      .oneOrMore()
+      .literal('function')
+      .whitespace()
+      .oneOrMore()
+      .literal(fnName)
+      .wordBoundary()
+      .toRegExp('is');
+    const deprecated = hasDeprecatedTag(declaration.span, code) || deprecatedBeforeFn.test(code);
     addSignature(`${prefix}${fnName}`, parameterTexts, explicitReturn, deprecated, '', '', declaration);
   };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,5 @@
 export const normalizeSpace = (value: string): string => value.replace(/\s+/g, ' ').trim();
 
-export const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
 const DEPRECATED_MARKER = '[deprecated] ';
 
 // The extractor prepends this marker to deprecated signatures; strip it so

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,8 +1,11 @@
 import { globby } from 'globby';
 import fs from 'fs-extra';
 import path from 'path';
+import { regex } from 'shorol';
 import type { FunctionSignature } from './extractor.js';
-import { escapeRegExp, normalizeSpace, stripDeprecatedMarker } from './utils.js';
+import { normalizeSpace, stripDeprecatedMarker } from './utils.js';
+
+const functionLikeBlock = regex().word().oneOrMore().whitespace().zeroOrMore().literal('(').toRegExp();
 
 const signatureLiterals = (content: string): string[] => {
   const matches = content.match(/`([^`]+)`/g) ?? [];
@@ -76,7 +79,7 @@ export async function checkDrift(
 
   for (const sig of signatures) {
     const normalizedSig = stripDeprecatedMarker(normalizeSpace(sig.fullSignature));
-    const nameRegex = new RegExp(`\\b${escapeRegExp(sig.name)}\\b`);
+    const nameRegex = regex().wordBoundary().literal(sig.name).wordBoundary().toRegExp();
     let nameFound = false;
     let signatureFound = false;
 
@@ -117,7 +120,7 @@ export async function checkDrift(
   }
 
   const unusedDocBlocks = [...allDocSignatureBlocks].filter(
-    (block) => /\w+\s*\(/.test(block) && !knownSignatureBlocks.has(stripDeprecatedMarker(block)),
+    (block) => functionLikeBlock.test(block) && !knownSignatureBlocks.has(stripDeprecatedMarker(block)),
   );
 
   if (unusedDocBlocks.length > 0) {


### PR DESCRIPTION
## Summary

Introduce shorol (a zero-dependency fluent regex builder) for the regex sites
where it adds real value: readable composition and automatic escaping of
caller-derived input. Added as a runtime dependency.

Converted:
- validator: the symbol-name word-boundary matcher (sig.name can contain a dot,
  which is why manual escaping was needed) and the function-like doc-block test.
- extractor: the dense deprecated-function fallback pattern. It uses toRegExp('is');
  the dotAll flag makes the any() spans equivalent to the previous [\s\S] spans.
- utils: removed escapeRegExp, now unused. It was an incidental re-export, never
  part of the documented API (extractSignatures / checkDrift).

Left as native regex on purpose (converting would add noise, not clarity): the
trivial static patterns such as the whitespace collapse, the file-extension test,
the backtick and JSDoc block matchers, and the lazy-quantifier matcher (shorol
has no lazy quantifier).

## Verification

npm ci, typecheck, lint, test, build all pass in a node:22 container. The
shorol-built patterns were checked to produce equivalent regex sources and
matching behaviour before conversion.

## Release note

This is a refactor, so semantic-release will not cut a version; the new shorol
dependency ships with the next release.
