### PR TITLE
chore(dependabot): ignore undici major (dev-only, pinned to v6 upstream)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
       # ts-jest and typescript-eslint peer-require typescript < 7.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # undici (dev-only, via @actions/http-client) pins ^6; undici 7 breaks the tree.
+      - dependency-name: "undici"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "chore(deps)"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

Ignore major-version updates for undici. undici is a dev-only transitive
dependency (pulled in by @actions/http-client via @semantic-release/npm), and
@actions/http-client pins undici to ^6, so undici 7 cannot be installed cleanly
and breaks the dependency tree.

Minor and patch undici updates within the 6.x line are still allowed, so any
adoptable 6.x security fix continues to flow.

This closes the un-adoptable undici 7 PR (#156). The remaining undici advisory
is against the copy bundled inside npm (node-gyp), which is dev-only and cannot
be replaced by a dependency bump or override; it clears when the Node base image
updates.
