### PR TITLE
feat: drift remediation hints and GitHub Actions annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ npx doc-sync-check <source-dir> --docs <docs-dir>
 - `--check-descriptions`: Compares JSDoc descriptions against markdown text.
 - `--update-readme`: Updates function list between README markers.
 - `--config`: Path to the config file (default: `.doc-sync-checkrc.json`).
+- `--annotate`: Emits GitHub Actions annotations and a job summary. Auto-enabled when running under GitHub Actions; use `--no-annotate` to turn it off.
 - `--init`: Writes a starter `.doc-sync-checkrc.json`.
 - `--slack-webhook` and `--discord-webhook`: Sends drift failure notifications.
 
@@ -80,6 +81,31 @@ npx doc-sync-check src --include "docs/**/*.md" "README.md" --strict
 - Coverage can be exported in Sonar/Cobertura-friendly formats.
 - Drift failures can notify Slack/Discord webhooks.
 - VSCode extension scaffold is available under `.vscode-extension/`.
+
+### GitHub Actions
+
+Under GitHub Actions, drift, undocumented, and unused-block findings are emitted
+as annotations that appear inline on the pull request diff, and a summary table
+is written to the job summary. Annotations are on automatically when
+`GITHUB_ACTIONS` is set; pass `--annotate`/`--no-annotate` to force it either way.
+
+```yaml
+name: docs
+on: [pull_request]
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npx doc-sync-check src --include "docs/**/*.md" "README.md" --strict
+```
+
+When a documented signature is stale, the output also prints the exact
+up-to-date signature to paste into the docs.
 
 ## Website
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { contentHash, DEFAULT_CACHE_PATH, loadCache, saveCache } from './cache.j
 import { notifyDriftFailure } from './integrations.js';
 import { updateReadmeFunctions } from './readme.js';
 import { DEFAULT_CONFIG_PATH, loadFileConfig, type FileConfig } from './config.js';
+import { emitGithubAnnotations, isGithubActions, writeStepSummary } from './reporters.js';
 
 const cli = meow(
   `
@@ -35,6 +36,7 @@ const cli = meow(
 	  --update-readme       Auto-write exported signatures to README markers
 	  --readme-path         README path for --update-readme (default: ./README.md)
 	  --config              Config file path (default: .doc-sync-checkrc.json)
+	  --annotate            Emit GitHub Actions annotations (default: auto in CI)
 	  --init                Write a starter .doc-sync-checkrc.json
 
 	Examples
@@ -59,6 +61,7 @@ const cli = meow(
       checkDescriptions: { type: 'boolean' },
       updateReadme: { type: 'boolean' },
       readmePath: { type: 'string' },
+      annotate: { type: 'boolean' },
       config: { type: 'string', default: DEFAULT_CONFIG_PATH },
       init: { type: 'boolean', default: false },
     },
@@ -173,6 +176,9 @@ async function run() {
   const checkDescriptions = pick('checkDescriptions');
   const updateReadme = pick('updateReadme');
   const readmePath = pick('readmePath');
+  const annotate = flagWasProvided('annotate')
+    ? Boolean(cli.flags.annotate)
+    : (fileConfig.annotate ?? isGithubActions());
 
   const docPatterns =
     include && include.length > 0
@@ -222,6 +228,11 @@ async function run() {
   const result = await checkDrift(allSigs, docPatterns, { checkDescriptions });
 
   console.log(`\n📈 Coverage: ${result.coveragePercent}% documented (${result.documentedSymbols}/${allSigs.length})`);
+
+  if (annotate) {
+    emitGithubAnnotations(result.findings);
+    await writeStepSummary(result);
+  }
 
   if (coverageOut) {
     if (coverageFormat === 'sonar') await writeSonarReport(result, coverageOut);

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export interface FileConfig {
   checkDescriptions?: boolean;
   updateReadme?: boolean;
   readmePath?: string;
+  annotate?: boolean;
 }
 
 export const DEFAULT_CONFIG_PATH = '.doc-sync-checkrc.json';
@@ -28,7 +29,7 @@ const STRING_KEYS = [
   'readmePath',
 ] as const;
 
-const BOOLEAN_KEYS = ['strict', 'cache', 'fixDocs', 'checkDescriptions', 'updateReadme'] as const;
+const BOOLEAN_KEYS = ['strict', 'cache', 'fixDocs', 'checkDescriptions', 'updateReadme', 'annotate'] as const;
 
 // Keep only known fields whose type matches, so a wrong-typed value falls back
 // to the default instead of crashing later (e.g. a non-string reaching path.join).

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export * from './ast/index.js';
 export * from './cache.js';
 export * from './integrations.js';
 export * from './config.js';
+export * from './reporters.js';
 export * from './utils.js';

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -1,0 +1,66 @@
+import fs from 'fs-extra';
+import type { DriftResult, DriftFinding } from './validator.js';
+
+export const isGithubActions = (): boolean => process.env.GITHUB_ACTIONS === 'true';
+
+// GitHub escapes command data and properties differently; see the workflow-command spec.
+const escapeData = (value: string): string =>
+  value.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+
+const escapeProperty = (value: string): string =>
+  escapeData(value).replace(/:/g, '%3A').replace(/,/g, '%2C');
+
+const titleFor = (finding: DriftFinding): string => {
+  switch (finding.kind) {
+    case 'drift':
+      return 'Documentation drift';
+    case 'description-drift':
+      return 'Description drift';
+    case 'unused-doc-block':
+      return 'Unused documentation block';
+    default:
+      return 'Undocumented export';
+  }
+};
+
+const annotationBody = (finding: DriftFinding): string =>
+  finding.expected ? `${finding.message} Expected: ${finding.expected}` : finding.message;
+
+// Emit GitHub Actions workflow commands so findings surface inline on the PR diff.
+export function emitGithubAnnotations(
+  findings: DriftFinding[],
+  log: (line: string) => void = console.log,
+): void {
+  for (const finding of findings) {
+    const props = [`title=${escapeProperty(titleFor(finding))}`];
+    if (finding.file) props.push(`file=${escapeProperty(finding.file)}`);
+    if (finding.line) props.push(`line=${finding.line}`);
+    log(`::${finding.severity} ${props.join(',')}::${escapeData(annotationBody(finding))}`);
+  }
+}
+
+const summaryTable = (result: DriftResult): string => {
+  const rows = result.findings.map((f) => {
+    const location = f.file ? `${f.file}${f.line ? `:${f.line}` : ''}` : '-';
+    const target = f.symbol ?? f.expected ?? '-';
+    return `| ${f.severity} | ${f.kind} | ${target} | ${location} |`;
+  });
+  const header = '| Severity | Kind | Symbol | Location |\n| --- | --- | --- | --- |';
+  return rows.length > 0 ? `${header}\n${rows.join('\n')}` : '_No issues found._';
+};
+
+// Append a run summary to $GITHUB_STEP_SUMMARY when GitHub provides it.
+export async function writeStepSummary(result: DriftResult): Promise<void> {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  const body = [
+    '## doc-sync-check',
+    '',
+    `**Coverage:** ${result.coveragePercent}% documented ` +
+      `(${result.inSyncSymbols} in sync, ${result.driftedSymbols} drifted, ${result.undocumentedSymbols} undocumented)`,
+    '',
+    summaryTable(result),
+    '',
+  ].join('\n');
+  await fs.appendFile(summaryPath, body, 'utf-8');
+}

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -7,10 +7,27 @@ import { normalizeSpace, stripDeprecatedMarker } from './utils.js';
 
 const functionLikeBlock = regex().word().oneOrMore().whitespace().zeroOrMore().literal('(').toRegExp();
 
-const signatureLiterals = (content: string): string[] => {
-  const matches = content.match(/`([^`]+)`/g) ?? [];
-  return matches.map((m) => normalizeSpace(m.slice(1, -1)));
+// 1-based line number of the given character offset within content.
+const lineAt = (content: string, index: number): number =>
+  index < 0 ? 1 : content.slice(0, index).split('\n').length;
+
+// Location of the first substring/regex match in content, or null if absent.
+const locate = (content: string, matcher: string | RegExp): { line: number } | null => {
+  const index = typeof matcher === 'string' ? content.indexOf(matcher) : content.search(matcher);
+  return index < 0 ? null : { line: lineAt(content, index) };
 };
+
+export type DriftFindingKind = 'drift' | 'undocumented' | 'unused-doc-block' | 'description-drift';
+
+export interface DriftFinding {
+  kind: DriftFindingKind;
+  severity: 'error' | 'warning';
+  message: string;
+  symbol?: string;
+  file?: string;
+  line?: number;
+  expected?: string;
+}
 
 export interface DriftResult {
   hasDrift: boolean;
@@ -21,6 +38,7 @@ export interface DriftResult {
   unusedDocBlocks: string[];
   coveragePercent: number;
   descriptionDriftSymbols: string[];
+  findings: DriftFinding[];
 }
 
 export interface CheckDriftOptions {
@@ -44,6 +62,7 @@ export async function checkDrift(
       unusedDocBlocks: [],
       coveragePercent: signatures.length === 0 ? 100 : 0,
       descriptionDriftSymbols: [],
+      findings: [],
     };
   }
 
@@ -54,7 +73,10 @@ export async function checkDrift(
         path: file,
         content,
         normalizedContent: normalizeSpace(content),
-        signatureBlocks: signatureLiterals(content),
+        blocks: [...content.matchAll(/`([^`]+)`/g)].map((m) => ({
+          text: normalizeSpace(m[1]),
+          line: lineAt(content, m.index ?? 0),
+        })),
       };
     }),
   );
@@ -65,11 +87,7 @@ export async function checkDrift(
   let driftedSymbols = 0;
   let undocumentedSymbols = 0;
   const descriptionDriftSymbols: string[] = [];
-  const allDocSignatureBlocks = new Set<string>();
-
-  docs.forEach((doc) => {
-    doc.signatureBlocks.forEach((block) => allDocSignatureBlocks.add(block));
-  });
+  const findings: DriftFinding[] = [];
 
   // Docs are not expected to carry the extractor's [deprecated] marker, so we
   // compare against the marker-free form on both sides.
@@ -80,27 +98,39 @@ export async function checkDrift(
   for (const sig of signatures) {
     const normalizedSig = stripDeprecatedMarker(normalizeSpace(sig.fullSignature));
     const nameRegex = regex().wordBoundary().literal(sig.name).wordBoundary().toRegExp();
-    let nameFound = false;
+    let mentionedIn: { path: string; content: string } | null = null;
     let signatureFound = false;
 
     for (const doc of docs) {
       if (nameRegex.test(doc.content)) {
-        nameFound = true;
+        if (!mentionedIn) mentionedIn = doc;
         if (doc.normalizedContent.includes(normalizedSig)) {
           signatureFound = true;
+          mentionedIn = doc;
           break;
         }
       }
     }
 
-    if (nameFound) documentedSymbols += 1;
+    if (mentionedIn) documentedSymbols += 1;
+    const line = mentionedIn ? (locate(mentionedIn.content, nameRegex)?.line ?? undefined) : undefined;
 
-    if (nameFound && !signatureFound) {
-      console.error(`❌ DRIFT DETECTED: Symbol '${sig.name}' is mentioned in documentation, but the updated signature was not found.`);
-      console.error(`   Expected to find: ${normalizedSig}`);
+    if (mentionedIn && !signatureFound) {
       hasDrift = true;
       driftedSymbols += 1;
-    } else if (nameFound && signatureFound) {
+      findings.push({
+        kind: 'drift',
+        severity: 'error',
+        symbol: sig.name,
+        file: mentionedIn.path,
+        line,
+        expected: normalizedSig,
+        message: `'${sig.name}' is mentioned in documentation, but its up-to-date signature was not found.`,
+      });
+      console.error(`❌ DRIFT: '${sig.name}' is stale in ${mentionedIn.path}${line ? `:${line}` : ''}`);
+      console.error('   Replace the documented signature with:');
+      console.error(`     \`${normalizedSig}\``);
+    } else if (mentionedIn && signatureFound) {
       console.log(`✅ IN SYNC: '${sig.name}' is correctly documented.`);
       inSyncSymbols += 1;
       if (options.checkDescriptions && sig.jsDocDescription) {
@@ -110,21 +140,51 @@ export async function checkDrift(
         if (!descriptionFound) {
           hasDrift = true;
           descriptionDriftSymbols.push(sig.name);
+          findings.push({
+            kind: 'description-drift',
+            severity: 'error',
+            symbol: sig.name,
+            file: mentionedIn.path,
+            line,
+            message: `'${sig.name}' JSDoc description was not found in the documentation.`,
+          });
           console.error(`❌ DESCRIPTION DRIFT: '${sig.name}' JSDoc description not found in docs.`);
         }
       }
     } else {
-      console.log(`⚠️  UNDOCUMENTED: '${sig.name}' was not found in any documentation.`);
       undocumentedSymbols += 1;
+      findings.push({
+        kind: 'undocumented',
+        severity: 'warning',
+        symbol: sig.name,
+        message: `'${sig.name}' was not found in any documentation.`,
+      });
+      console.log(`⚠️  UNDOCUMENTED: '${sig.name}' was not found in any documentation.`);
     }
   }
 
-  const unusedDocBlocks = [...allDocSignatureBlocks].filter(
-    (block) => functionLikeBlock.test(block) && !knownSignatureBlocks.has(stripDeprecatedMarker(block)),
-  );
+  const unusedDocBlocks: string[] = [];
+  const seenUnused = new Set<string>();
+  for (const doc of docs) {
+    for (const block of doc.blocks) {
+      const stripped = stripDeprecatedMarker(block.text);
+      if (!functionLikeBlock.test(block.text) || knownSignatureBlocks.has(stripped) || seenUnused.has(stripped)) {
+        continue;
+      }
+      seenUnused.add(stripped);
+      unusedDocBlocks.push(block.text);
+      hasDrift = true;
+      findings.push({
+        kind: 'unused-doc-block',
+        severity: 'error',
+        file: doc.path,
+        line: block.line,
+        message: `Documented signature '${block.text}' is not present in source exports.`,
+      });
+    }
+  }
 
   if (unusedDocBlocks.length > 0) {
-    hasDrift = true;
     console.error('❌ UNUSED DOC BLOCKS: Found signature blocks not present in source exports.');
     unusedDocBlocks.forEach((block) => console.error(`   - ${block}`));
   }
@@ -142,6 +202,7 @@ export async function checkDrift(
     unusedDocBlocks,
     coveragePercent,
     descriptionDriftSymbols,
+    findings,
   };
 }
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -62,7 +62,12 @@ export async function checkDrift(
       unusedDocBlocks: [],
       coveragePercent: signatures.length === 0 ? 100 : 0,
       descriptionDriftSymbols: [],
-      findings: [],
+      findings: signatures.map((sig) => ({
+        kind: 'undocumented',
+        severity: 'warning',
+        symbol: sig.name,
+        message: `'${sig.name}' was not found in any documentation.`,
+      })),
     };
   }
 

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -1,0 +1,95 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { emitGithubAnnotations, isGithubActions, writeStepSummary } from '../src/reporters.js';
+import type { DriftFinding, DriftResult } from '../src/validator.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const baseResult = (findings: DriftFinding[]): DriftResult => ({
+  hasDrift: findings.some((f) => f.severity === 'error'),
+  documentedSymbols: 1,
+  inSyncSymbols: 0,
+  driftedSymbols: findings.filter((f) => f.kind === 'drift').length,
+  undocumentedSymbols: findings.filter((f) => f.kind === 'undocumented').length,
+  unusedDocBlocks: [],
+  coveragePercent: 50,
+  descriptionDriftSymbols: [],
+  findings,
+});
+
+describe('emitGithubAnnotations', () => {
+  it('emits a file-and-line error command for a drift finding', () => {
+    const lines: string[] = [];
+    emitGithubAnnotations(
+      [{ kind: 'drift', severity: 'error', symbol: 'compute', file: 'docs/api.md', line: 5, expected: 'compute(v: number): number', message: 'stale' }],
+      (line) => lines.push(line),
+    );
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe('::error title=Documentation drift,file=docs/api.md,line=5::stale Expected: compute(v: number): number');
+  });
+
+  it('emits a warning without file or line for an undocumented finding', () => {
+    const lines: string[] = [];
+    emitGithubAnnotations(
+      [{ kind: 'undocumented', severity: 'warning', symbol: 'hidden', message: 'not documented' }],
+      (line) => lines.push(line),
+    );
+    expect(lines[0]).toBe('::warning title=Undocumented export::not documented');
+  });
+
+  it('escapes newlines and commas in the message and file property', () => {
+    const lines: string[] = [];
+    emitGithubAnnotations(
+      [{ kind: 'drift', severity: 'error', file: 'a,b.md', line: 1, message: 'line1\nline2' }],
+      (line) => lines.push(line),
+    );
+    expect(lines[0]).toContain('file=a%2Cb.md');
+    expect(lines[0]).toContain('line1%0Aline2');
+  });
+});
+
+describe('writeStepSummary', () => {
+  const tempDir = path.join(__dirname, 'temp_summary');
+
+  beforeEach(async () => {
+    await fs.ensureDir(tempDir);
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+    delete process.env.GITHUB_STEP_SUMMARY;
+  });
+
+  it('appends a coverage line and findings table to the summary file', async () => {
+    const summaryPath = path.join(tempDir, 'summary.md');
+    process.env.GITHUB_STEP_SUMMARY = summaryPath;
+    await writeStepSummary(
+      baseResult([{ kind: 'drift', severity: 'error', symbol: 'compute', file: 'docs/api.md', line: 5, message: 'stale' }]),
+    );
+    const written = await fs.readFile(summaryPath, 'utf-8');
+    expect(written).toContain('Coverage:** 50% documented');
+    expect(written).toContain('| error | drift | compute | docs/api.md:5 |');
+  });
+
+  it('does nothing when GITHUB_STEP_SUMMARY is not set', async () => {
+    delete process.env.GITHUB_STEP_SUMMARY;
+    await expect(writeStepSummary(baseResult([]))).resolves.toBeUndefined();
+  });
+});
+
+describe('isGithubActions', () => {
+  const original = process.env.GITHUB_ACTIONS;
+  afterEach(() => {
+    if (original === undefined) delete process.env.GITHUB_ACTIONS;
+    else process.env.GITHUB_ACTIONS = original;
+  });
+
+  it('is true only when GITHUB_ACTIONS equals the string "true"', () => {
+    process.env.GITHUB_ACTIONS = 'true';
+    expect(isGithubActions()).toBe(true);
+    process.env.GITHUB_ACTIONS = 'false';
+    expect(isGithubActions()).toBe(false);
+  });
+});

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -145,3 +145,67 @@ describe('Validator (1.3.0 scope)', () => {
     expect(result.unusedDocBlocks).toEqual([]);
   });
 });
+
+describe('Validator findings (annotations + hints)', () => {
+  const tempDocsDir = path.join(__dirname, 'temp_findings');
+
+  beforeEach(async () => {
+    await fs.ensureDir(tempDocsDir);
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDocsDir);
+  });
+
+  it('reports a drift finding with file, line, and the expected signature', async () => {
+    const sigs: FunctionSignature[] = [
+      {
+        name: 'compute',
+        parameters: ['v: number'],
+        returnType: ': number',
+        fullSignature: 'compute(v: number): number',
+      },
+    ];
+    await fs.writeFile(
+      path.join(tempDocsDir, 'docs.md'),
+      '# API\n\nSome intro.\n\n`compute(v: string): number`\n',
+    );
+    const result = await checkDrift(sigs, path.join(tempDocsDir, '**/*.md'));
+
+    const drift = result.findings.find((f) => f.kind === 'drift');
+    expect(drift).toBeDefined();
+    expect(drift?.severity).toBe('error');
+    expect(drift?.symbol).toBe('compute');
+    expect(drift?.expected).toBe('compute(v: number): number');
+    expect(drift?.file).toContain('docs.md');
+    expect(drift?.line).toBe(5);
+  });
+
+  it('reports undocumented symbols as warnings without a location', async () => {
+    const sigs: FunctionSignature[] = [
+      { name: 'hidden', parameters: [], returnType: ': void', fullSignature: 'hidden(): void' },
+    ];
+    await fs.writeFile(path.join(tempDocsDir, 'docs.md'), '# API\n\nNothing relevant here.\n');
+    const result = await checkDrift(sigs, path.join(tempDocsDir, '**/*.md'));
+
+    const undocumented = result.findings.find((f) => f.kind === 'undocumented');
+    expect(undocumented?.severity).toBe('warning');
+    expect(undocumented?.file).toBeUndefined();
+  });
+
+  it('reports an unused doc block with its origin file and line', async () => {
+    const sigs: FunctionSignature[] = [
+      { name: 'activeFn', parameters: [], returnType: ': void', fullSignature: 'activeFn(): void' },
+    ];
+    await fs.writeFile(
+      path.join(tempDocsDir, 'docs.md'),
+      '`activeFn(): void`\n\n`removedFn(x: string): boolean`\n',
+    );
+    const result = await checkDrift(sigs, path.join(tempDocsDir, '**/*.md'));
+
+    const unused = result.findings.find((f) => f.kind === 'unused-doc-block');
+    expect(unused?.severity).toBe('error');
+    expect(unused?.file).toContain('docs.md');
+    expect(unused?.line).toBe(3);
+  });
+});

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -193,6 +193,18 @@ describe('Validator findings (annotations + hints)', () => {
     expect(undocumented?.file).toBeUndefined();
   });
 
+  it('reports every symbol as undocumented when no markdown files match', async () => {
+    const sigs: FunctionSignature[] = [
+      { name: 'alpha', parameters: [], returnType: ': void', fullSignature: 'alpha(): void' },
+      { name: 'beta', parameters: [], returnType: ': void', fullSignature: 'beta(): void' },
+    ];
+    const result = await checkDrift(sigs, path.join(tempDocsDir, 'nope', '**/*.md'));
+
+    expect(result.undocumentedSymbols).toBe(2);
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.every((f) => f.kind === 'undocumented' && f.severity === 'warning')).toBe(true);
+  });
+
   it('reports an unused doc block with its origin file and line', async () => {
     const sigs: FunctionSignature[] = [
       { name: 'activeFn', parameters: [], returnType: ': void', fullSignature: 'activeFn(): void' },


### PR DESCRIPTION
## Summary

Two related improvements that make the CI drift-gating experience actionable,
sharing one data-model change.

### Remediation hints (closes #93)
When a documented signature is stale, the output now names the doc file and line
and prints the exact up-to-date signature to paste in.

### GitHub Actions annotations (closes #97)
Findings are emitted as workflow-command annotations that appear inline on the
pull request diff, and a coverage + findings table is written to the job summary.
A new --annotate flag drives this; it auto-enables under GITHUB_ACTIONS and can be
forced with --annotate / --no-annotate. Also selectable via the config file.

### Shared change
checkDrift now returns a structured findings[] list
(kind, severity, symbol, file, line, expected). Existing count fields and
unusedDocBlocks / descriptionDriftSymbols are kept for backward compatibility.

## Verification
- typecheck, lint, test, build all pass locally and in a node:22 container.
- 31 tests (28 pass, 3 pre-existing skips); new tests cover the findings model,
  the reporters output and escaping, the step summary, and the no-docs path.
- End-to-end run of --annotate verified: correct inline annotations and summary.

## Release
feat, so semantic-release will cut v1.7.0 on merge.
