### PR TITLE
feat: version and document the JSON report schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,41 @@ jobs:
 When a documented signature is stale, the output also prints the exact
 up-to-date signature to paste into the docs.
 
+## JSON report schema
+
+The default `--coverage-format json` output carries a `schemaVersion` so
+consumers can detect the format. The current version is `1`:
+
+```json
+{
+  "schemaVersion": 1,
+  "hasDrift": true,
+  "documentedSymbols": 8,
+  "inSyncSymbols": 7,
+  "driftedSymbols": 1,
+  "undocumentedSymbols": 2,
+  "unusedDocBlocks": ["removedFn(x: string): boolean"],
+  "coveragePercent": 80,
+  "descriptionDriftSymbols": [],
+  "findings": [
+    {
+      "kind": "drift",
+      "severity": "error",
+      "symbol": "createUser",
+      "file": "docs/api.md",
+      "line": 14,
+      "expected": "createUser(input: CreateUserInput): Promise<User>",
+      "message": "'createUser' is mentioned in documentation, but its up-to-date signature was not found."
+    }
+  ]
+}
+```
+
+`findings[]` entries have `kind` (`drift`, `undocumented`, `unused-doc-block`,
+`description-drift`), `severity` (`error` or `warning`), and, where known,
+`symbol`, `file`, `line`, and `expected`. The `sonar` format carries the same
+`schemaVersion`. `schemaVersion` is bumped only when the shape changes.
+
 ## Website
 
 A simple project website scaffold is available in `website/` for GitHub Pages.

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -240,8 +240,8 @@ export async function writeCoverageBadge(result: DriftResult, outputPath: string
   const color = result.coveragePercent >= 90 ? 'brightgreen' : result.coveragePercent >= 70 ? 'yellow' : 'red';
   const badgeUrl = `https://img.shields.io/badge/doc_coverage-${result.coveragePercent}%25-${color}`;
   const payload: CoverageReport = {
-    schemaVersion: REPORT_SCHEMA_VERSION,
     ...result,
+    schemaVersion: REPORT_SCHEMA_VERSION,
     badgeUrl,
     generatedAt: new Date().toISOString(),
   };

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -45,6 +45,31 @@ export interface CheckDriftOptions {
   checkDescriptions?: boolean;
 }
 
+// Bumped whenever the shape of a written JSON report changes, so consumers can
+// detect the format they are reading. See the JSON report schema in the README.
+export const REPORT_SCHEMA_VERSION = 1;
+
+export interface CoverageReport extends DriftResult {
+  schemaVersion: number;
+  badgeUrl: string;
+  generatedAt: string;
+}
+
+export interface SonarReport {
+  schemaVersion: number;
+  project: string;
+  metrics: {
+    documentedSymbols: number;
+    inSyncSymbols: number;
+    driftedSymbols: number;
+    undocumentedSymbols: number;
+    coveragePercent: number;
+    unusedDocBlocks: number;
+    descriptionDriftSymbols: number;
+  };
+  generatedAt: string;
+}
+
 export async function checkDrift(
   signatures: FunctionSignature[],
   docPatterns: string | string[],
@@ -214,7 +239,8 @@ export async function checkDrift(
 export async function writeCoverageBadge(result: DriftResult, outputPath: string): Promise<void> {
   const color = result.coveragePercent >= 90 ? 'brightgreen' : result.coveragePercent >= 70 ? 'yellow' : 'red';
   const badgeUrl = `https://img.shields.io/badge/doc_coverage-${result.coveragePercent}%25-${color}`;
-  const payload = {
+  const payload: CoverageReport = {
+    schemaVersion: REPORT_SCHEMA_VERSION,
     ...result,
     badgeUrl,
     generatedAt: new Date().toISOString(),
@@ -226,7 +252,8 @@ export async function writeCoverageBadge(result: DriftResult, outputPath: string
 }
 
 export async function writeSonarReport(result: DriftResult, outputPath: string): Promise<void> {
-  const payload = {
+  const payload: SonarReport = {
+    schemaVersion: REPORT_SCHEMA_VERSION,
     project: 'doc-sync-check',
     metrics: {
       documentedSymbols: result.documentedSymbols,

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -1,7 +1,13 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { checkDrift } from '../src/validator.js';
+import {
+  checkDrift,
+  writeCoverageBadge,
+  writeSonarReport,
+  REPORT_SCHEMA_VERSION,
+} from '../src/validator.js';
+import type { DriftResult } from '../src/validator.js';
 import type { FunctionSignature } from '../src/extractor.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -219,5 +225,51 @@ describe('Validator findings (annotations + hints)', () => {
     expect(unused?.severity).toBe('error');
     expect(unused?.file).toContain('docs.md');
     expect(unused?.line).toBe(3);
+  });
+});
+
+describe('JSON report schema', () => {
+  const tempDir = path.join(__dirname, 'temp_reports');
+
+  const sampleResult = (): DriftResult => ({
+    hasDrift: true,
+    documentedSymbols: 2,
+    inSyncSymbols: 1,
+    driftedSymbols: 1,
+    undocumentedSymbols: 0,
+    unusedDocBlocks: [],
+    coveragePercent: 50,
+    descriptionDriftSymbols: [],
+    findings: [
+      { kind: 'drift', severity: 'error', symbol: 'compute', file: 'docs/api.md', line: 5, expected: 'compute(v: number): number', message: 'stale' },
+    ],
+  });
+
+  beforeEach(async () => {
+    await fs.ensureDir(tempDir);
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  it('stamps schemaVersion and carries findings in the coverage report', async () => {
+    const out = path.join(tempDir, 'coverage.json');
+    await writeCoverageBadge(sampleResult(), out);
+    const report = JSON.parse(await fs.readFile(out, 'utf-8'));
+
+    expect(report.schemaVersion).toBe(REPORT_SCHEMA_VERSION);
+    expect(report.coveragePercent).toBe(50);
+    expect(report.findings[0]).toMatchObject({ kind: 'drift', file: 'docs/api.md', line: 5 });
+    expect(typeof report.badgeUrl).toBe('string');
+  });
+
+  it('stamps schemaVersion in the sonar report', async () => {
+    const out = path.join(tempDir, 'sonar.json');
+    await writeSonarReport(sampleResult(), out);
+    const report = JSON.parse(await fs.readFile(out, 'utf-8'));
+
+    expect(report.schemaVersion).toBe(REPORT_SCHEMA_VERSION);
+    expect(report.metrics.coveragePercent).toBe(50);
   });
 });


### PR DESCRIPTION
## Summary

Give the JSON reports a versioned, documented schema so consumers (Codecov,
SonarQube, custom tooling) can rely on the format.

- Add REPORT_SCHEMA_VERSION (starting at 1) and stamp a schemaVersion field into
  the json coverage report and the sonar report. Cobertura XML is unchanged (it
  carries its own version attribute).
- Export typed CoverageReport and SonarReport interfaces.
- Document the schema in the README, including the findings[] shape added in the
  previous release. This is the baseline (version 1) for the current shape;
  schemaVersion is bumped only when the shape changes.

Closes #98.

## Verification
- typecheck, lint, test, build all pass locally and in a node:22 container.
- 33 tests (30 pass, 3 pre-existing skips); new tests write both reports and
  assert schemaVersion and shape.
- Emitted JSON confirmed to carry schemaVersion: 1 for json and sonar formats.

## Release
feat, so semantic-release will cut v1.8.0 on merge.
